### PR TITLE
Add mixing length models and docs

### DIFF
--- a/src/EDMF/Models/buoyancy.jl
+++ b/src/EDMF/Models/buoyancy.jl
@@ -1,6 +1,17 @@
 ##### Buoyancy models
 
-@inline buoyancy(param_set, α_0, α) = grav(param_set) * (α - α_0)/α_0
+@inline buoyancy(param_set, α_0::FT, α::FT) where {FT} = FT(grav(param_set)) * (α - α_0)/α_0
+
+"""
+    compute_buoyancy!
+
+Define buoyancy field
+
+ - `tmp[:buoy, k, i]`
+
+ for all `k` and all `i`
+"""
+function compute_buoyancy! end
 
 function compute_buoyancy!(grid, q, tmp, params)
   gm, en, ud, sd, al = allcombinations(q)
@@ -36,9 +47,9 @@ function compute_tke_buoy!(grid::Grid{FT}, q, tmp, tmp_O2, cv, params) where FT
   gm, en, ud, sd, al = allcombinations(q)
   @unpack params param_set
 
-  _R_v = R_v(param_set)
-  _R_d = R_d(param_set)
-  _grav = grav(param_set)
+  _R_v::FT = R_v(param_set)
+  _R_d::FT = R_d(param_set)
+  _grav::FT = grav(param_set)
 
   # Note that source terms at the first interior point are not really used because that is where tke boundary condition is
   # enforced (according to MO similarity). Thus here I am being sloppy about lowest grid point

--- a/src/EDMF/Models/eddy_diffusivity.jl
+++ b/src/EDMF/Models/eddy_diffusivity.jl
@@ -1,9 +1,22 @@
 ##### Eddy-diffusivity models
 
 abstract type EddyDiffusivityModel end
+
 struct SCAMPyEddyDiffusivity{FT} <: EddyDiffusivityModel
   tke_ed_coeff::FT
 end
+
+"""
+    compute_eddy_diffusivities_tke!
+
+Define eddy-diffusivity fields
+
+ - `tmp[:K_m, k, i]`
+ - `tmp[:K_h, k, i]`
+
+ for all `k` and all `i`
+"""
+function compute_eddy_diffusivities_tke! end
 
 function compute_eddy_diffusivities_tke!(grid::Grid{FT}, q, tmp, params, model::SCAMPyEddyDiffusivity) where FT
   gm, en, ud, sd, al = allcombinations(q)

--- a/src/EDMF/Models/entr_detr.jl
+++ b/src/EDMF/Models/entr_detr.jl
@@ -6,6 +6,19 @@ struct BOverW2{FT} <: EntrDetrModel
   ε_factor::FT
   δ_factor::FT
 end
+
+"""
+    compute_entrainment_detrainment!
+
+Define entrainment and detrainment fields
+
+ - `tmp[:ε_model, k, i]`
+ - `tmp[:δ_model, k, i]`
+
+ for all `k` and all `i`
+"""
+function compute_entrainment_detrainment! end
+
 function compute_entrainment_detrainment!(grid::Grid{FT}, UpdVar, tmp, q, params, model::BOverW2) where FT
   gm, en, ud, sd, al = allcombinations(q)
   Δzi = grid.Δzi

--- a/src/EDMF/Models/microphysics.jl
+++ b/src/EDMF/Models/microphysics.jl
@@ -1,5 +1,21 @@
 ##### Microphysics models
 
+"""
+    compute_cloud_phys!
+
+Define microphysics fields
+ - `tmp[:CF, k, i]`
+ - `tmp[:θ_cloudy, k, i]`
+ - `tmp[:t_cloudy, k, i]`
+ - `tmp[:q_tot_cloudy, k, i]`
+ - `tmp[:q_vap_cloudy, k, i]`
+ - `tmp[:θ_dry, k, i]`
+ - `tmp[:q_tot_dry, k, i]`
+
+ for all `k` and all `i`
+"""
+function compute_cloud_phys! end
+
 function compute_cloud_phys!(grid::Grid{FT}, q, tmp, params) where FT
   gm, en, ud, sd, al = allcombinations(q)
   @unpack params param_set

--- a/src/EDMF/Models/mixing_length.jl
+++ b/src/EDMF/Models/mixing_length.jl
@@ -2,13 +2,138 @@
 
 abstract type MixingLengthModel end
 
+#####
+##### Types
+#####
+
+"""
+    ConstantMixingLength
+
+TODO: add docs
+"""
 struct ConstantMixingLength{FT} <: MixingLengthModel
   value::FT
 end
+
+"""
+    SCAMPyMixingLength
+
+TODO: add docs
+"""
+struct SCAMPyMixingLength{FT} <: MixingLengthModel
+  a_L::StabilityDependentParam{FT}
+  b_L::StabilityDependentParam{FT}
+end
+
+"""
+    IgnaciosMixingLength
+
+TODO: add docs
+"""
+struct IgnaciosMixingLength{FT} <: MixingLengthModel
+  a_L::StabilityDependentParam{FT}
+  b_L::StabilityDependentParam{FT}
+  c_K::FT
+  c_ε::FT
+  c_w::FT
+  ω_1::FT
+  ω_2::FT
+  function IgnaciosMixingLength(a_L::StabilityDependentParam{FT},
+                                b_L::StabilityDependentParam{FT},
+                                c_K::FT,
+                                c_ε::FT,
+                                c_w::FT,
+                                ω_1::FT) where FT
+    return new{FT}(a_L, b_L, c_K, c_ε, c_w, ω_1, ω_1 + 1)
+  end
+end
+
+######
+###### Helper funcs
+######
+
+"""
+    compute_mixing_τ
+
+TODO: add docs
+"""
+compute_mixing_τ(zi::FT, wstar::FT) where FT = zi / (wstar + FT(0.001))
+
+"""
+    ϕ_m
+
+TODO: add docs
+"""
+ϕ_m(ξ, a_L, b_L) = (1+a_L*ξ)^(-b_L)
+
+######
+###### Compute mixing length methods
+######
+
+"""
+    compute_mixing_length!
+
+Define mixing length
+
+ - `tmp[:l_mix, k, i]`
+
+for all `k` and all `i`
+"""
+function compute_mixing_length! end
 
 function compute_mixing_length!(grid::Grid{FT}, q, tmp, params, model::ConstantMixingLength) where FT
   gm, en, ud, sd, al = allcombinations(q)
   @inbounds for k in over_elems(grid)
     tmp[:l_mix, k, gm] = model.value
+  end
+end
+
+function compute_mixing_length!(grid::Grid{FT}, q, tmp, params, model::SCAMPyMixingLength{FT}) where FT
+  @unpack params obukhov_length zi wstar k_Karman
+  gm, en, ud, sd, al = allcombinations(q)
+  τ = compute_mixing_τ(zi, wstar)
+  a_L = model.a_L(obukhov_length)
+  b_L = model.b_L(obukhov_length)
+  @inbounds for k in over_elems_real(grid)
+    l1 = τ * sqrt(max(q[:tke, k, en], FT(0)))
+    z = grid.zc[k]
+    ξ = z/obukhov_length
+    l2 = k_Karman * z * ϕ_m(ξ, a_L, b_L)
+    tmp[:l_mix, k, gm] = max( 1/(1/max(l1,1e-10) + 1/l2), FT(1e-3))
+  end
+end
+
+function compute_mixing_length!(grid::Grid{FT}, q, tmp, params, model::IgnaciosMixingLength{FT}) where FT
+  @unpack params Prandtl_neutral obukhov_length SurfaceModel k_Karman param_set
+  gm, en, ud, sd, al = allcombinations(q)
+  ustar = SurfaceModel.ustar
+  L = Vector(undef, 3)
+  a_L = model.a_L(obukhov_length)
+  b_L = model.b_L(obukhov_length)
+  @inbounds for k in over_elems_real(grid)
+    TKE_k = max(q[:tke, k, en], FT(0))
+    θ_ρ = tmp[:θ_ρ, k, gm]
+    z = grid.zc[k]
+    ts_dual = ActiveThermoState(param_set, q, tmp, Dual(k), gm)
+    θ_ρ_dual = virtual_pottemp.(ts_dual)
+    ∇θ_ρ = ∇_z_flux(θ_ρ_dual, grid)
+    buoyancy_freq = FT(grav(param_set))*∇θ_ρ/θ_ρ
+    L[1] = sqrt(model.c_w*TKE_k)/buoyancy_freq
+    ξ = z/obukhov_length
+    κ_star = ustar/sqrt(TKE_k)
+    L[2] = k_Karman*z/(model.c_K*κ_star*ϕ_m(ξ, a_L, b_L))
+    S_squared = ∇_z_flux(q[:u, Dual(k), gm], grid)^2 +
+                ∇_z_flux(q[:v, Dual(k), gm], grid)^2 +
+                ∇_z_flux(q[:w, Dual(k), en], grid)^2
+    R_g = tmp[:∇buoyancy, k, gm]/S_squared
+    if unstable(obukhov_length)
+      Pr_z = Prandtl_neutral
+    else
+      discriminant1 = -4*R_g+(1+model.ω_2*R_g)^2
+      Pr_z = Prandtl_neutral*(1+model.ω_2*R_g - sqrt(discriminant1))/(2*R_g)
+    end
+    discriminant2 = S_squared - tmp[:∇buoyancy, k, gm]/Pr_z
+    L[3] = sqrt(model.c_ε/model.c_K)*sqrt(TKE_k)*1/sqrt(max(discriminant2, 1e-2))
+    tmp[:l_mix, k, gm] = sum([L[j]*exp(-L[j]) for j in 1:3])/sum([exp(-L[j]) for j in 1:3])
   end
 end

--- a/src/EDMF/Models/pressure.jl
+++ b/src/EDMF/Models/pressure.jl
@@ -8,6 +8,17 @@ Base.@kwdef struct SCAMPyPressure{FT} <: PressureModel
   plume_spacing::FT=FT(0)
 end
 
+"""
+    compute_pressure!
+
+Define pressure field
+
+ - `tmp[:nh_press, k, i]`
+
+for all `k` and all `i`
+"""
+function compute_pressure! end
+
 function compute_pressure!(grid::Grid{FT}, q, tmp, params, model::SCAMPyPressure) where FT
   gm, en, ud, sd, al = allcombinations(q)
   p_coeff = model.drag_coeff/model.plume_spacing

--- a/src/EDMF/aux_funcs.jl
+++ b/src/EDMF/aux_funcs.jl
@@ -29,6 +29,20 @@ quantities at element `k`.
                                        tmp[:p_0, k])
 end
 
+"""
+    ActiveThermoState(q, tmp, k, i)
+
+Returns a `ThermodynamicState` using grid-mean
+quantities at element `k`.
+"""
+@inline function ActiveThermoState(param_set, q, tmp, k::Dual, i)
+  return LiquidIcePotTempSHumEquil_old.(Ref(param_set),
+                                        q[:θ_liq, k, i],
+                                        q[:q_tot, k, i],
+                                        tmp[:ρ_0, k],
+                                        tmp[:p_0, k])
+end
+
 function update_dt!(grid, params, q, t)
   gm, en, ud, sd, al = allcombinations(q)
   @unpack params Δt Δt_min

--- a/src/EDMF/edmf_funcs.jl
+++ b/src/EDMF/edmf_funcs.jl
@@ -4,6 +4,26 @@ bound(x, x_bounds) = min(max(x, x_bounds[1]), x_bounds[2])
 
 inside_bounds(x, x_bounds) = x > x_bounds[1] && x < x_bounds[2]
 
+
+stable(obukhov_length::FT) where FT = obukhov_length>0
+unstable(obukhov_length::FT) where FT = obukhov_length<0
+
+"""
+    StabilityDependentParam
+
+A parameter that has two values:
+ - `stable` for stable conditions
+ - `unstable` for unstable conditions
+"""
+struct StabilityDependentParam{FT}
+  stable::FT
+  unstable::FT
+end
+
+function (sdp::StabilityDependentParam{FT})(obukhov_length::FT) where FT
+  return unstable(obukhov_length) ? sdp.unstable : sdp.stable
+end
+
 function assign_new_to_values!(grid, q_new, q, tmp)
   gm, en, ud, sd, al = allcombinations(q)
   @inbounds for k in over_elems(grid), i in ud, name in (:w, :q_tot, :θ_liq)

--- a/src/EDMF/init_params.jl
+++ b/src/EDMF/init_params.jl
@@ -16,9 +16,14 @@ function Params(param_set, ::BOMEX)
   params = Dict()
 
   #####
+  ##### TODO: Parameters that need to be added to CLIMAParameters
+  #####
+  params[:k_Karman] = 0.4 # "Von Karman constant (unit-less)"
+  params[:Prandtl_neutral]        = FT(1)
+
+  #####
   ##### Filter parameters
   #####
-  params[:k_Karman] = 0.4 # "Von Karman constant (unit-less)", TODO: add to CLIMAParameters
   params[:param_set] = param_set
   params[:N_subdomains] = 3
 
@@ -59,7 +64,17 @@ function Params(param_set, ::BOMEX)
   #####
 
   params[:EntrDetrModel]          = BOverW2{FT}(1, 1)
+  # Looks okay
   params[:MixingLengthModel]      = ConstantMixingLength{FT}(100)
+  # Looks okay
+  # params[:MixingLengthModel]      = SCAMPyMixingLength{FT}(StabilityDependentParam{FT}(2.7,-100.0),
+  #                                                          StabilityDependentParam{FT}(-1.0,-0.2))
+
+  # Getting NaNs for TKE and other fields. Something needs to be fixed
+  # params[:MixingLengthModel]      = IgnaciosMixingLength(StabilityDependentParam{FT}(2.7,-100.0),
+  #                                                        StabilityDependentParam{FT}(-1.0,-0.2),
+  #                                                        0.1, 0.12, 0.4, 40/13)
+
   params[:EddyDiffusivityModel]   = SCAMPyEddyDiffusivity{FT}(0.1)
 
   params[:PressureModel]          = SCAMPyPressure{FT}(;buoy_coeff=FT(1.0/3.0),
@@ -84,7 +99,9 @@ function Params(param_set, ::BOMEX)
 
   params[:inversion_height] = [1.0 for i in 1:params[:N_subdomains]]  # inversion height
   params[:Ri_bulk_crit] = 0.0                                         # inversion height parameters
-  params[:bflux] = (grav(param_set) * ((8.0e-3 + (molmass_ratio(param_set)-1.0)*(299.1 * 5.2e-5  + 22.45e-3 * 8.0e-3)) /(299.1 * (1.0 + (molmass_ratio(param_set)-1) * 22.45e-3))))
+  _molmass_ratio::FT = FT(molmass_ratio(param_set))
+  _grav::FT = FT(grav(param_set))
+  params[:bflux] = (_grav * ((8.0e-3 + (_molmass_ratio-1)*(299.1 * 5.2e-5  + 22.45e-3 * 8.0e-3)) /(299.1 * (1.0 + (_molmass_ratio-1) * 22.45e-3))))
   params[:cq] = 0.001133                                              # Some surface parameter in SCAMPy
   params[:ch] = 0.001094                                              # Some surface parameter in SCAMPy
   params[:cm] = 0.001229                                              # Some surface parameter in SCAMPy

--- a/src/EDMF/ref_states.jl
+++ b/src/EDMF/ref_states.jl
@@ -15,7 +15,7 @@ Initializes the reference state variables:
 assuming a hydrostatic balance.
 FIXME: add reference
 """
-function init_ref_state!(tmp::StateVec, grid::Grid, params, dir_tree::DirTree)
+function init_ref_state!(tmp::StateVec, grid::Grid{FT}, params, dir_tree::DirTree) where {FT}
   @unpack params param_set SurfaceModel
   T_g = SurfaceModel.T
   q_tot_g = SurfaceModel.q_tot
@@ -31,7 +31,7 @@ function init_ref_state!(tmp::StateVec, grid::Grid, params, dir_tree::DirTree)
     ts = LiquidIcePotTempSHumEquil_old(param_set, θ_liq_ice_g, q_tot_g, ρ, expp)
     R_m = gas_constant_air(ts)
     T = air_temperature(ts)
-    return - grav(param_set) / (T * R_m)
+    return - FT(grav(param_set)) / (T * R_m)
   end
 
   z_span = (grid.zn_min, grid.zn_max)

--- a/src/EDMF/turb_conv_models.jl
+++ b/src/EDMF/turb_conv_models.jl
@@ -72,6 +72,7 @@ function TurbConv(params, case::Case)
   (:HVSD_w                 , DomainSubSet(ud=true)),
   (:buoy                   , DomainSubSet(gm=true,en=true,ud=true)),
   (:nh_press               , DomainSubSet(ud=true)),
+  (:∇buoyancy              , DomainSubSet(gm=true)),
   (:δ_model                , DomainSubSet(ud=true)),
   (:ε_model                , DomainSubSet(ud=true)),
   (:l_mix                  , DomainSubSet(gm=true)),

--- a/src/EDMF/update_surface.jl
+++ b/src/EDMF/update_surface.jl
@@ -107,12 +107,12 @@ end
 Computes the inversion height (a non-local variable)
 FIXME: add reference
 """
-function compute_inversion_height(tmp::StateVec, q::StateVec, grid::Grid, params)
+function compute_inversion_height(tmp::StateVec, q::StateVec, grid::Grid{FT}, params) where {FT}
   @unpack params Ri_bulk_crit param_set SurfaceModel
   gm, en, ud, sd, al = allcombinations(q)
   k_1 = first_interior(grid, Zmin())
   windspeed = compute_windspeed(q, k_1, gm, 0.0)^2
-  _grav = grav(param_set)
+  _grav::FT = grav(param_set)
 
   # test if we need to look at the free convective limit
   z = grid.zc


### PR DESCRIPTION
Adds some doc strings/stubs, some `FT` type restrictions, and mixing length models:
 - `SCAMPyMixingLength`
 - `IgnaciosMixingLength`

The `SCAMPyMixingLength` model seems to work okay, but the results need to be reviewed @yairchn. The `IgnaciosMixingLength` model results in NaNs for the TKE field, and some other fields, so something is broken there that needs to be fixed. Adding both in for now, hopefully we'll get both working soon.